### PR TITLE
[TC-CNET-4.11] Refactor WiFi connection logic into reusable module (wifi.py)

### DIFF
--- a/src/python_testing/TC_CNET_4_11.py
+++ b/src/python_testing/TC_CNET_4_11.py
@@ -20,10 +20,9 @@ import logging
 
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
+from matter_testing_infrastructure.chip.testing.wifi import (MAX_RETRIES, TIMED_REQUEST_TIMEOUT_MS, TIMEOUT, WIFI_WAIT_SECONDS,
+                                                             change_networks, connect_host_wifi)
 from mobly import asserts
-
-from python_testing.matter_testing_infrastructure.chip.testing.wifi import TIMEOUT, MAX_RETRIES, WIFI_WAIT_SECONDS, TIMED_REQUEST_TIMEOUT_MS, change_networks, connect_host_wifi
-
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/src/python_testing/TC_CNET_4_11.py
+++ b/src/python_testing/TC_CNET_4_11.py
@@ -17,204 +17,20 @@
 
 import asyncio
 import logging
-import platform
-import shutil
-import subprocess
 
 import chip.clusters as Clusters
 from chip.testing.matter_testing import MatterBaseTest, TestStep, default_matter_test_main, has_feature, run_if_endpoint_matches
 from mobly import asserts
 
+from python_testing.matter_testing_infrastructure.chip.testing.wifi import TIMEOUT, MAX_RETRIES, WIFI_WAIT_SECONDS, TIMED_REQUEST_TIMEOUT_MS, change_networks, connect_host_wifi
+
+
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
-
-MAX_RETRIES = 5
-TIMEOUT = 900
-TIMED_REQUEST_TIMEOUT_MS = 5000
-WIFI_WAIT_SECONDS = 5
 
 cgen = Clusters.GeneralCommissioning
 cnet = Clusters.NetworkCommissioning
 attr = cnet.Attributes
-
-
-async def connect_wifi_linux(ssid, password):
-    """ Connects to WiFi with the SSID and Password provided as arguments using 'nmcli' in Linux."""
-    if isinstance(ssid, bytes):
-        ssid = ssid.decode()
-    if isinstance(password, bytes):
-        password = password.decode()
-
-    if not shutil.which("nmcli"):
-        logger.error("'nmcli' is not installed. Install with: sudo apt install network-manager")
-        return None
-
-    result = None
-    try:
-        # Activates Wi-Fi in case it is deactivated
-        subprocess.run(["nmcli", "radio", "wifi", "on"], check=False)
-
-        # Detects the active Wi-Fi interface
-        interface_result = subprocess.run(
-            ["nmcli", "-t", "-f", "DEVICE,TYPE,STATE", "device"],
-            capture_output=True, text=True
-        )
-        interface = None
-        for line in interface_result.stdout.strip().splitlines():
-            parts = line.split(":")
-            if len(parts) >= 3 and parts[1] == "wifi":
-                interface = parts[0]
-                if parts[2] == "connected":
-                    # Disconnecting interface
-                    subprocess.run(["nmcli", "device", "disconnect", interface], check=False)
-                break
-
-        # Let's try to connect
-        result = subprocess.run(
-            ["nmcli", "d", "wifi", "connect", ssid, "password", password],
-            capture_output=True, text=True
-        )
-        # wait the connection to be ready
-        await asyncio.sleep(WIFI_WAIT_SECONDS)
-
-        # Let's verify it is connected
-        check = subprocess.run(
-            ["nmcli", "-t", "-f", "ACTIVE,SSID", "dev", "wifi"],
-            capture_output=True, text=True
-        )
-        if any(line.startswith("yes:" + ssid) for line in check.stdout.splitlines()):
-            logger.info(f" --- connect_wifi_linux: Successfully connected to '{ssid}'")
-        else:
-            logger.info(f" --- connect_wifi_linux: Could not confirm WiFi connection to '{ssid}'")
-
-    except subprocess.CalledProcessError as e:
-        logger.error(f" --- connect_wifi_linux: nmcli command failed: {e.stderr.strip()}")
-    except Exception as e:
-        logger.error(f" --- connect_wifi_linux: Unexpected exception when trying to connect to '{ssid}': {e}")
-    finally:
-        return result
-
-
-async def connect_wifi_mac(ssid, password):
-    """ Connects to WiFi with the SSID and Password provided as arguments using 'networksetup' in Mac."""
-    if not shutil.which("networksetup"):
-        logger.error(" --- connect_wifi_mac: 'networksetup' is not present. Please install 'networksetup'.")
-        return None
-
-    result = None
-    try:
-        # Get the Wi-Fi interface
-        interface_result = subprocess.run(
-            ["/usr/sbin/networksetup", "-listallhardwareports"],
-            capture_output=True, text=True
-        )
-        interface = "en0"   # 'en0' is by default
-        for block in interface_result.stdout.split("\n\n"):
-            if "Wi-Fi" in block:
-                for line in block.splitlines():
-                    if "Device" in line:
-                        interface = line.split(":")[1].strip()
-                        break
-
-        logger.info(f" --- connect_wifi_mac: Using interface: {interface}")
-        result = subprocess.run([
-            "networksetup",
-            "-setairportnetwork", interface, ssid, password
-        ], check=True, capture_output=True, text=True)
-        await asyncio.sleep(WIFI_WAIT_SECONDS)
-
-    except subprocess.CalledProcessError as e:
-        logger.error(f" --- connect_wifi_mac: Error connecting with networksetup: {e.stderr.strip()}")
-    except Exception as e:
-        logger.error(f" --- connect_wifi_mac: Unexpected exception while trying to connect to {ssid}: {e}")
-    finally:
-        return result
-
-
-async def connect_host_wifi(ssid, password):
-    """ Checks in which OS (Linux or Darwin only) the script is running and calls the corresponding connect_wifi function. """
-    os_name = platform.system()
-    logger.info(f" --- connect_host_wifi: OS detected: {os_name}")
-
-    # Let's try to connect the TH to the second network a few times, to avoid network instability
-    retry = 1
-    while retry <= MAX_RETRIES:
-        logger.info(f" --- connect_host_wifi: Trying to connect to {ssid} - {retry}/{MAX_RETRIES}")
-        try:
-            conn = None
-            if os_name == "Linux":
-                conn = await connect_wifi_linux(ssid, password)
-            elif os_name == "Darwin":
-                conn = await connect_wifi_mac(ssid, password)
-            else:
-                logger.error(" --- connect_host_wifi: OS not supported.")
-            if conn and conn.returncode == 0:
-                logger.info(f" --- connect_host_wifi: Connected to {ssid}")
-                break
-            elif conn:
-                stderr_msg = conn.stderr if conn.stderr else "No stderr"
-                logger.error(
-                    f" --- connect_host_wifi: Attempt {retry} failed. Return code: {conn.returncode} stderr: {stderr_msg}")
-            else:
-                logger.error(" --- connect_host_wifi: No result returned from connection attempt.")
-
-        except subprocess.CalledProcessError as e:
-            logger.error(
-                f" --- connect_host_wifi: Exception: {e} when trying to connect to {ssid} stderr: {conn.stderr.decode()}")
-        finally:
-            retry += 1
-
-
-def is_network_switch_successful(err):
-    """ Verifies if networkingStatus is 0 (kSuccess) """
-    return (
-        err is None or
-        (hasattr(err, "networkingStatus") and
-         err.networkingStatus == cnet.Enums.NetworkCommissioningStatusEnum.kSuccess)
-    )
-
-
-async def change_networks(test, cluster, ssid, password, breadcrumb):
-    """ Changes networks in DUT by sending ConnectNetwork command and
-        changes TH network by calling connect_host_wifi function."""
-    # ConnectNetwork tells the DUT to change to the second Wi-Fi network, while TH stays in the first one
-    # so they loose connection between each other. Thus, ConnectNetwork can throw an exception
-    retry = 1
-    while retry <= MAX_RETRIES:
-        try:
-            if retry > 1:
-                # Let's wait a couple seconds to finish changing networks
-                await asyncio.sleep(WIFI_WAIT_SECONDS)
-            err = await asyncio.wait_for(
-                test.send_single_cmd(
-                    cmd=cluster.Commands.ConnectNetwork(
-                        networkID=ssid,
-                        breadcrumb=breadcrumb
-                    )
-                ),
-                timeout=TIMEOUT
-            )
-            logger.info(f" --- change_networks: err type: {type(err)}, value: {err}")
-            success = is_network_switch_successful(err)
-            if success:
-                logger.info(" --- change_networks: Network switch successful.")
-                break
-            else:
-                logger.warning(f" --- change_networks: Error during network switch: {err}")
-
-        except Exception as e:
-            logger.error(f" --- change_networks: Lost connection with the DUT. Exception: {e}")
-
-        # After telling the DUT to change networks, we must change TH to the second network, so it can find the DUT
-        # But first wait a couple of seconds so the DUT finishes changing networks
-        await asyncio.sleep(WIFI_WAIT_SECONDS)
-        await asyncio.wait_for(
-            connect_host_wifi(ssid=ssid, password=password),
-            timeout=TIMEOUT
-        )
-        retry += 1
-    else:
-        logger.error(f" --- change_networks: Failed to switch networks after {MAX_RETRIES} retries.")
 
 
 class TC_CNET_4_11(MatterBaseTest):

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/wifi.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/wifi.py
@@ -1,0 +1,210 @@
+#
+#    Copyright (c) 2022-2025 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import asyncio
+import logging
+import platform
+import shutil
+import subprocess
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+MAX_RETRIES = 5
+TIMEOUT = 900
+TIMED_REQUEST_TIMEOUT_MS = 5000
+WIFI_WAIT_SECONDS = 5
+
+
+async def connect_wifi_linux(ssid, password):
+    """ Connects to WiFi with the SSID and Password provided as arguments using 'nmcli' in Linux."""
+    if isinstance(ssid, bytes):
+        ssid = ssid.decode()
+    if isinstance(password, bytes):
+        password = password.decode()
+
+    if not shutil.which("nmcli"):
+        logger.error("'nmcli' is not installed. Install with: sudo apt install network-manager")
+        return None
+
+    result = None
+    try:
+        # Activates Wi-Fi in case it is deactivated
+        subprocess.run(["nmcli", "radio", "wifi", "on"], check=False)
+
+        # Detects the active Wi-Fi interface
+        interface_result = subprocess.run(
+            ["nmcli", "-t", "-f", "DEVICE,TYPE,STATE", "device"],
+            capture_output=True, text=True
+        )
+        interface = None
+        for line in interface_result.stdout.strip().splitlines():
+            parts = line.split(":")
+            if len(parts) >= 3 and parts[1] == "wifi":
+                interface = parts[0]
+                if parts[2] == "connected":
+                    # Disconnecting interface
+                    subprocess.run(["nmcli", "device", "disconnect", interface], check=False)
+                break
+
+        # Let's try to connect
+        result = subprocess.run(
+            ["nmcli", "d", "wifi", "connect", ssid, "password", password],
+            capture_output=True, text=True
+        )
+        # wait the connection to be ready
+        await asyncio.sleep(WIFI_WAIT_SECONDS)
+
+        # Let's verify it is connected
+        check = subprocess.run(
+            ["nmcli", "-t", "-f", "ACTIVE,SSID", "dev", "wifi"],
+            capture_output=True, text=True
+        )
+        if any(line.startswith("yes:" + ssid) for line in check.stdout.splitlines()):
+            logger.info(f" --- connect_wifi_linux: Successfully connected to '{ssid}'")
+        else:
+            logger.info(f" --- connect_wifi_linux: Could not confirm WiFi connection to '{ssid}'")
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f" --- connect_wifi_linux: nmcli command failed: {e.stderr.strip()}")
+    except Exception as e:
+        logger.error(f" --- connect_wifi_linux: Unexpected exception when trying to connect to '{ssid}': {e}")
+    finally:
+        return result
+
+
+async def connect_wifi_mac(ssid, password):
+    """ Connects to WiFi with the SSID and Password provided as arguments using 'networksetup' in Mac."""
+    if not shutil.which("networksetup"):
+        logger.error(" --- connect_wifi_mac: 'networksetup' is not present. Please install 'networksetup'.")
+        return None
+
+    result = None
+    try:
+        # Get the Wi-Fi interface
+        interface_result = subprocess.run(
+            ["/usr/sbin/networksetup", "-listallhardwareports"],
+            capture_output=True, text=True
+        )
+        interface = "en0"   # 'en0' is by default
+        for block in interface_result.stdout.split("\n\n"):
+            if "Wi-Fi" in block:
+                for line in block.splitlines():
+                    if "Device" in line:
+                        interface = line.split(":")[1].strip()
+                        break
+
+        logger.info(f" --- connect_wifi_mac: Using interface: {interface}")
+        result = subprocess.run([
+            "networksetup",
+            "-setairportnetwork", interface, ssid, password
+        ], check=True, capture_output=True, text=True)
+        await asyncio.sleep(WIFI_WAIT_SECONDS)
+
+    except subprocess.CalledProcessError as e:
+        logger.error(f" --- connect_wifi_mac: Error connecting with networksetup: {e.stderr.strip()}")
+    except Exception as e:
+        logger.error(f" --- connect_wifi_mac: Unexpected exception while trying to connect to {ssid}: {e}")
+    finally:
+        return result
+
+
+async def connect_host_wifi(ssid, password):
+    """ Checks in which OS (Linux or Darwin only) the script is running and calls the corresponding connect_wifi function. """
+    os_name = platform.system()
+    logger.info(f" --- connect_host_wifi: OS detected: {os_name}")
+
+    # Let's try to connect the TH to the second network a few times, to avoid network instability
+    retry = 1
+    while retry <= MAX_RETRIES:
+        logger.info(f" --- connect_host_wifi: Trying to connect to {ssid} - {retry}/{MAX_RETRIES}")
+        try:
+            conn = None
+            if os_name == "Linux":
+                conn = await connect_wifi_linux(ssid, password)
+            elif os_name == "Darwin":
+                conn = await connect_wifi_mac(ssid, password)
+            else:
+                logger.error(" --- connect_host_wifi: OS not supported.")
+            if conn and conn.returncode == 0:
+                logger.info(f" --- connect_host_wifi: Connected to {ssid}")
+                break
+            elif conn:
+                stderr_msg = conn.stderr if conn.stderr else "No stderr"
+                logger.error(
+                    f" --- connect_host_wifi: Attempt {retry} failed. Return code: {conn.returncode} stderr: {stderr_msg}")
+            else:
+                logger.error(" --- connect_host_wifi: No result returned from connection attempt.")
+
+        except subprocess.CalledProcessError as e:
+            logger.error(
+                f" --- connect_host_wifi: Exception: {e} when trying to connect to {ssid} stderr: {conn.stderr.decode()}")
+        finally:
+            retry += 1
+
+
+def is_network_switch_successful(err):
+    """ Verifies if networkingStatus is 0 (kSuccess) """
+    return (
+        err is None or
+        (hasattr(err, "networkingStatus") and
+         err.networkingStatus == cnet.Enums.NetworkCommissioningStatusEnum.kSuccess)
+    )
+
+
+async def change_networks(test, cluster, ssid, password, breadcrumb):
+    """ Changes networks in DUT by sending ConnectNetwork command and
+        changes TH network by calling connect_host_wifi function."""
+    # ConnectNetwork tells the DUT to change to the second Wi-Fi network, while TH stays in the first one
+    # so they loose connection between each other. Thus, ConnectNetwork can throw an exception
+    retry = 1
+    while retry <= MAX_RETRIES:
+        try:
+            if retry > 1:
+                # Let's wait a couple seconds to finish changing networks
+                await asyncio.sleep(WIFI_WAIT_SECONDS)
+            err = await asyncio.wait_for(
+                test.send_single_cmd(
+                    cmd=cluster.Commands.ConnectNetwork(
+                        networkID=ssid,
+                        breadcrumb=breadcrumb
+                    )
+                ),
+                timeout=TIMEOUT
+            )
+            logger.info(f" --- change_networks: err type: {type(err)}, value: {err}")
+            success = is_network_switch_successful(err)
+            if success:
+                logger.info(" --- change_networks: Network switch successful.")
+                break
+            else:
+                logger.warning(f" --- change_networks: Error during network switch: {err}")
+
+        except Exception as e:
+            logger.error(f" --- change_networks: Lost connection with the DUT. Exception: {e}")
+
+        # After telling the DUT to change networks, we must change TH to the second network, so it can find the DUT
+        # But first wait a couple of seconds so the DUT finishes changing networks
+        await asyncio.sleep(WIFI_WAIT_SECONDS)
+        await asyncio.wait_for(
+            connect_host_wifi(ssid=ssid, password=password),
+            timeout=TIMEOUT
+        )
+        retry += 1
+    else:
+        logger.error(f" --- change_networks: Failed to switch networks after {MAX_RETRIES} retries.")


### PR DESCRIPTION
### Testing
This PR refactors the WiFi connection logic used in TC-CNET-4.11 into a separate module (`wifi.py`) under `matter_testing_infrastructure/chip/testing/`. The objective is to modularize platform-specific WiFi operations (Linux and macOS) and ensure consistency across tests that require TH WiFi switching.

### Changes:
- Moved WiFi switching functions (`connect_host_wifi`, `connect_wifi_mac`, `connect_wifi_linux`) to `wifi.py`.
- Added utility functions:
  - `is_network_switch_successful`: Verifies NetworkCommissioningStatusEnum.
  - `change_networks`: Handles DUT and TH WiFi switching with retries.
  - `verify_operational_network`: Ensures the DUT is operational in the expected SSID.
- Added docstrings and type hinting to all functions.
- Updated `TC_CNET_4_11.py` to use the new functions from `wifi.py`.

### Test Validation:
- Test executed successfully on ESP32 running All-Clusters-App.
- Verified proper WiFi network handover between TH and DUT.
- Logs confirm DUT connection transitions (SSID1 ↔ SSID2) were successful with no critical failures.
- No regressions observed in network commissioning flow.

### Notes:
- This PR is a fix for branch `tc_cnet_4_11`, requested in Issue [#40426.](https://github.com/project-chip/connectedhomeip/issues/40426)
- The base branch for this PR is `tc_cnet_4_11`.

Testing:
Since this is a wifi test, to reproduce test steps there are some physical devices needed.
You will need:

Device: ESP32C6
WiFi: you'll need two WiFi networks with corresponding SSIDs and Passphrases that will be provided in the CLI to run the script.

```
In one terminal:
# 1. check out ESP-IDF tool and install it
#    using the instructions on the page below
# https://project-chip.github.io/connectedhomeip-doc/platforms/esp32/setup_idf_chip.html

Get ESP-IDF v5.3
mkdir ~/esp
cd ~/esp
git clone -b v5.3 --recursive --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git
cd ~/esp/esp-idf
./install.sh

# 2. go to connectedhomeip project home
source scripts/bootstrap.sh
source scripts/activate.sh
python3 -m pip install esptool 

# 3. Run export.sh 
source ../esp/esp-idf/export.sh

# 4. Run activate.sh again
source scripts/activate.sh

# 5. IDF set-target
idf.py -C examples/all-clusters-app/esp32 set-target esp32c6
# probably you will need to remove examples/all-clusters-app/esp32/build before running previous command
# you will need to modify examples/all-clusters-app/esp32/partitions.csv to re-flash
ota_0,    app,  ota_0,   ,        2500K,
# ota_0,    app,  ota_0,   ,        1900K,
# ota_1,    app,  ota_1,   ,        1900K,

# 6. IDF build
idf.py -C examples/all-clusters-app/esp32 build

Remove flash between runs:
idf.py -C examples/all-clusters-app/esp32 -p /dev/tty.usbserial-140 erase-flash

# 7. IDF flash
idf.py -C examples/all-clusters-app/esp32 -p /dev/tty.usbserial-140 flash monitor
# (in my case on Mac the device is called /dev/tty.tty.usbserial-140)
# (in my case on Linux the device is called /dev/ttyUSB0)


```
In a second terminal:

Run test:

`python3 src/python_testing/TC_CNET_4_11.py --commissioning-method ble-wifi --wifi-ssid <SSID1> --wifi-passphrase <Passphrase1> --discriminator 3840 --passcode 20202021 --string-arg PIXIT.CNET.WIFI_2ND_ACCESSPOINT_SSID:"SSID2" --string-arg PIXIT.CNET.WIFI_2ND_ACCESSPOINT_CREDENTIALS:"Passphrase2" --endpoint 0
`